### PR TITLE
Allow overriding Poetry constraint in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN npm run build
 # Stage 2: Execute the backend
 FROM python:3.10-slim-bullseye
 
+ARG POETRY_VERSION_CONSTRAINT=">=1.5,<1.7"
+
 # 1. Install required system packages
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PIP_DEFAULT_TIMEOUT 500
@@ -39,7 +41,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK 1
 ENV PIP_NO_CACHE_DIR 1
 RUN apt update                                            \
     && apt install -y build-essential libpq-dev
-RUN pip install poetry
+RUN pip install "poetry${POETRY_VERSION_CONSTRAINT}"
 
 # 2. Set working directory and copy files to container
 WORKDIR /root
@@ -53,7 +55,7 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONFAULTHANDLER 1
 ENV PYTHONHASHSEED random
-RUN poetry install --no-dev --no-interaction --no-ansi    \
+RUN poetry install --only main --no-interaction --no-ansi \
     && rm -rf ~/.cache
 
 # 4. Expose the required ports

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The project consists of three main components:
 docker build -t yaraku/human-evaluation-tool .
 ```
 
+> **Note:** The Docker build installs Poetry versions that satisfy `>=1.5,<1.7` by default. You can override the constraint with
+> `--build-arg POETRY_VERSION_CONSTRAINT="==1.6.1"` if you need to pin an exact release.
+
 2. Run the container:
 ```sh
 docker run --rm -it -p 8000:8000 yaraku/human-evaluation-tool
@@ -71,7 +74,7 @@ sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres';"
 ```sh
 cd backend
 
-# Install dependencies
+# Install dependencies (Poetry 1.5.x - 1.6.x)
 poetry install
 
 # Create and configure .env file


### PR DESCRIPTION
## Summary
- add a build argument so the Docker image can override the default Poetry constraint while still defaulting to 1.5.x-1.6.x
- document how to pin the Poetry version during Docker builds in the README

## Testing
- `poetry install --only main --no-interaction --no-ansi`
- `docker build -t he-tool .` *(fails: docker CLI not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68da248a0558832382565f8cef6e974d