### PR TITLE
Switch backend badges to genbadge

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -112,6 +112,17 @@ jobs:
           --cov-report=term-missing
           --cov-report=xml
 
+      - name: Collect Flake8 report for badge
+        working-directory: backend
+        run: poetry run flake8 src tests --exit-zero --output-file flake8.log
+
+      - name: Generate status badges
+        working-directory: backend
+        run: |
+          poetry run genbadge tests --local -i pytest-results.xml -o tests.svg
+          poetry run genbadge flake8 --local -i flake8.log -o flake8.svg
+          poetry run genbadge coverage --local -i coverage.xml -o coverage.svg
+
       - name: Upload pytest results
         if: always()
         uses: actions/upload-artifact@v4
@@ -119,11 +130,31 @@ jobs:
           name: pytest-results-${{ matrix.python-version }}
           path: backend/pytest-results.xml
 
+      - name: Upload coverage badge
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-badges-${{ matrix.python-version }}
+          path: |
+            backend/tests.svg
+            backend/flake8.svg
+            backend/coverage.svg
+
       - name: Publish Unit Test Results
         if: ${{ always() && github.event_name == 'pull_request' }}
         uses: EnricoMi/publish-unit-test-result-action/linux@v2
         with:
           files: backend/pytest-results.xml
+
+      - name: Commit coverage badge
+        if: ${{ github.event_name != 'pull_request' && matrix.python-version == '3.10' }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: chore: update backend status badges
+          file_pattern: |
+            backend/tests.svg
+            backend/flake8.svg
+            backend/coverage.svg
 
       - name: Post coverage comment
         if: ${{ github.event_name == 'pull_request' }}

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,5 +1,10 @@
 # Human Evaluation Tool Backend
 
+[![Backend CI](https://img.shields.io/github/actions/workflow/status/yaraku/he-tool/backend-ci.yml?branch=main&label=Backend%20CI)](https://github.com/yaraku/he-tool/actions/workflows/backend-ci.yml)
+![Tests](./tests.svg)
+![Flake8](./flake8.svg)
+![Coverage](./coverage.svg)
+
 The backend is a Flask + SQLAlchemy application that powers the Human Evaluation Tool. It exposes a REST API for managing evaluations, documents, bitext pairs, annotations, systems, markings, and authentication.
 
 ## Quick start

--- a/backend/coverage.svg
+++ b/backend/coverage.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="116" height="20" role="img" aria-label="coverage: 99.84%">
+	<title>coverage: 99.84%</title>
+	<linearGradient id="s" x2="0" y2="100%">
+		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+		<stop offset="1" stop-opacity=".1"/>
+	</linearGradient>
+	<clipPath id="r">
+		<rect width="116" height="20" rx="3" fill="#fff"/>
+	</clipPath>
+	<g clip-path="url(#r)">
+		<rect width="61" height="20" fill="#555"/>
+		<rect x="61" width="55" height="20" fill="#4c1"/>
+		<rect width="116" height="20" fill="url(#s)"/>
+	</g>
+	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+		<text aria-hidden="true" x="315.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text>
+		<text x="315.0" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
+		<text aria-hidden="true" x="875.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">99.84%</text>
+		<text x="875.0" y="140" transform="scale(.1)" fill="#fff" textLength="450">99.84%</text>
+	</g>
+</svg>

--- a/backend/flake8.svg
+++ b/backend/flake8.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="124" height="20" role="img" aria-label="flake8: 0 C, 0 W, 0 I">
+	<title>flake8: 0 C, 0 W, 0 I</title>
+	<linearGradient id="s" x2="0" y2="100%">
+		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+		<stop offset="1" stop-opacity=".1"/>
+	</linearGradient>
+	<clipPath id="r">
+		<rect width="124" height="20" rx="3" fill="#fff"/>
+	</clipPath>
+	<g clip-path="url(#r)">
+		<rect width="43" height="20" fill="#555"/>
+		<rect x="43" width="81" height="20" fill="#4c1"/>
+		<rect width="124" height="20" fill="url(#s)"/>
+	</g>
+	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+		<text aria-hidden="true" x="225.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">flake8</text>
+		<text x="225.0" y="140" transform="scale(.1)" fill="#fff" textLength="330">flake8</text>
+		<text aria-hidden="true" x="825.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="710">0 C, 0 W, 0 I</text>
+		<text x="825.0" y="140" transform="scale(.1)" fill="#fff" textLength="710">0 C, 0 W, 0 I</text>
+	</g>
+</svg>

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,7 @@ mypy = "^1.8"
 coverage = { extras = ["toml"], version = "^7.4" }
 pytest = "^7.4"
 pytest-cov = "^4.1"
+genbadge = { version = "^1.1", extras = ["flake8", "tests"] }
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/backend/tests.svg
+++ b/backend/tests.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="68" height="20" role="img" aria-label="tests: 119">
+	<title>tests: 119</title>
+	<linearGradient id="s" x2="0" y2="100%">
+		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+		<stop offset="1" stop-opacity=".1"/>
+	</linearGradient>
+	<clipPath id="r">
+		<rect width="68" height="20" rx="3" fill="#fff"/>
+	</clipPath>
+	<g clip-path="url(#r)">
+		<rect width="37" height="20" fill="#555"/>
+		<rect x="37" width="31" height="20" fill="#4c1"/>
+		<rect width="68" height="20" fill="url(#s)"/>
+	</g>
+	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
+		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
+		<text aria-hidden="true" x="515.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="210">119</text>
+		<text x="515.0" y="140" transform="scale(.1)" fill="#fff" textLength="210">119</text>
+	</g>
+</svg>

--- a/docs/backend/testing-and-quality.md
+++ b/docs/backend/testing-and-quality.md
@@ -27,7 +27,13 @@ poetry run coverage run -m pytest
 poetry run coverage report
 ```
 
-The goal is ≥99 % line coverage (the current suite hits 100 %). Branch coverage is enabled to surface unexecuted conditional logic.
+The goal is ≥99 % line coverage (the current suite hits 99 %). Branch coverage is enabled to surface unexecuted conditional logic. The GitHub Actions workflow also runs [`genbadge`](https://github.com/codacy/genbadge) to produce `backend/tests.svg`, `backend/flake8.svg`, and `backend/coverage.svg`, which appear at the top of the backend README. Locally, create `flake8.log` with `poetry run flake8 src tests --exit-zero --output-file flake8.log` and regenerate the badges after running the suite with:
+
+```bash
+poetry run genbadge tests --local -i pytest-results.xml -o tests.svg
+poetry run genbadge flake8 --local -i flake8.log -o flake8.svg
+poetry run genbadge coverage --local -i coverage.xml -o coverage.svg
+```
 
 ## Static typing with mypy
 


### PR DESCRIPTION
## Summary
- replace the deprecated coverage-badge dependency with genbadge and enable the required extras
- update the backend CI workflow to collect flake8 output and generate local tests, flake8, and coverage badges via genbadge
- surface the new badges in the backend README and document how to recreate them in the backend testing guide

## Testing
- poetry run pytest --junitxml=pytest-results.xml --cov=human_evaluation_tool --cov-report=term-missing --cov-report=xml


------
https://chatgpt.com/codex/tasks/task_b_68e8d4b5bc648323975493f05c54f40f